### PR TITLE
fixed handling of multiple children with same type and value

### DIFF
--- a/sqltools/sequence.py
+++ b/sqltools/sequence.py
@@ -27,16 +27,15 @@ class Sequence:
 
         left.attr['insert'] = []
 
-        for r in right.children:
+        for idx, r in enumerate(right.children):
             found = False
             for l in left.children:
                 if r.value == l.value and r.type == l.type:
                     found = True
                     break
 
-            if not found:
+            if not found or idx >= len(left.children):
                 left.attr['insert'].append(r)
-
 
         for l in left.children:
             if l.attr['status'] != Seq.copy:
@@ -144,6 +143,9 @@ def generate_sequence(left, right):
 def generate_sequence_sql(left, right, table_info=None):
     left, right = to_tree(left, table_info), to_tree(right, table_info)
     Sequence.compare(left, right)
+
+    tree_print(left, highlights=['status','insert'])
+
     seq = Sequence.generate_sequence(left, right)
     return seq
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -92,3 +92,9 @@ class SequenceTest(SqltoolsTest):
         sql2 = "SELECT * FROM teacher WHERE age = 32 and age = 33"
 
         self.assertEqual(apply_sequence_sql(sql1, generate_sequence_sql(sql1, sql2)), sql2)
+
+    def test_apply_sequence_sql11(self):
+        sql1 = "select age from singer where country = 'france'"
+        sql2 = "SELECT avg(age), min(age), max(age) FROM singer WHERE country = 'france'"
+
+        self.assertEqual(apply_sequence_sql(sql1, generate_sequence_sql(sql1, sql2)), sql2)


### PR DESCRIPTION
The problem was in the compare function. Since the children of SELECT all had type COL and value age, compare didn't add the extra COL[age] children. Fixed by adding every child whose "index" was greater than or equal to the length of left.children