### PR TITLE
fixed terminal bug

### DIFF
--- a/sqltools/sequence.py
+++ b/sqltools/sequence.py
@@ -10,9 +10,9 @@ class Sequence:
 
         candidate = True
 
-        for l in left.children:
+        for idxl, l in enumerate(left.children):
             found = False
-            for r in right.children:
+            for r in right.children[idxl:]:
                 if r.value == l.value and r.type == l.type:
                     res = Sequence.compare(l, r)
                     candidate = candidate and res
@@ -143,9 +143,6 @@ def generate_sequence(left, right):
 def generate_sequence_sql(left, right, table_info=None):
     left, right = to_tree(left, table_info), to_tree(right, table_info)
     Sequence.compare(left, right)
-
-    tree_print(left, highlights=['status','insert'])
-
     seq = Sequence.generate_sequence(left, right)
     return seq
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -98,3 +98,10 @@ class SequenceTest(SqltoolsTest):
         sql2 = "SELECT avg(age), min(age), max(age) FROM singer WHERE country = 'france'"
 
         self.assertEqual(apply_sequence_sql(sql1, generate_sequence_sql(sql1, sql2)), sql2)
+
+    def test_apply_sequence_sql12(self):
+        sql1 = "select * from votes where state = 'ny' or state = 'ca'"
+        sql2 = "SELECT count(*) FROM votes WHERE state = 'ny' or state = 'ca'"
+
+        self.assertEqual(apply_sequence_sql(sql1, generate_sequence_sql(sql1, sql2)), sql2)
+


### PR DESCRIPTION
The problem was that the nested for loops causes branches that weren't aligned with each other to be compared. Fixed by only allowing the left branch to compare with the right branches that are past the index of the left branch