### PR TITLE
modified process for labeling remove and copy

### DIFF
--- a/sqltools/sequence.py
+++ b/sqltools/sequence.py
@@ -10,9 +10,10 @@ class Sequence:
 
         candidate = True
 
+        idxt = 0
         for idxl, l in enumerate(left.children):
             found = False
-            for r in right.children[idxl:]:
+            for r in right.children[idxl-idxt:]:
                 if r.value == l.value and r.type == l.type:
                     res = Sequence.compare(l, r)
                     candidate = candidate and res
@@ -24,6 +25,7 @@ class Sequence:
 
             if not found:
                 l.attr['status'] = Seq.remove
+                idxt += 1
 
         left.attr['insert'] = []
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -153,3 +153,9 @@ class SequenceTest(SqltoolsTest):
     #     tree = to_tree(sql1)
 
     #     self.assertTreeEqual(get_node_from_sequence(tree, sequence[:2]), tree.children[0].children[0])
+
+    def test_apply_sequence_sql16(self):
+        sql1 = "select name, number_products from shop"
+        sql2 = "SELECT avg(number_products) FROM shop "
+
+        self.assertEqual(apply_sequence_sql(sql1, generate_sequence_sql(sql1, sql2)), sql2)


### PR DESCRIPTION
Same exact problem as will having multiple children with the same types and values. Fixed the same way (idxt = 0, increase idxt every time you remove, and then subtract idxt from idxl to get the true index of the child you should be checking against)